### PR TITLE
large wait (500 minutes) to avoid unnecessary spill to disk

### DIFF
--- a/data/vtlib/alignment_wtsi_stage2_template.json
+++ b/data/vtlib/alignment_wtsi_stage2_template.json
@@ -31,7 +31,8 @@
 		"type":"EXEC",
 		"use_STDIN": true,
 		"use_STDOUT": false,
-		"cmd":"teepot -w 300 -m 1G __PHIX_ALN_OUT__ __TGT_ALN_OUT__"
+		"comment":"large wait (500 minutes) to avoid unnecessary spill to disk",
+		"cmd":"teepot -w 30000 -m 1G __PHIX_ALN_OUT__ __TGT_ALN_OUT__"
 	},
 	{
 		"id":"pre_alignment_target",


### PR DESCRIPTION
had previously been an mbuffer
